### PR TITLE
Replaced login route /signin by /admin/login

### DIFF
--- a/src/ripe/base.py
+++ b/src/ripe/base.py
@@ -55,7 +55,7 @@ class Api(
     def login(self, username = None, password = None):
         username = username or self.username
         password = password or self.password
-        url = self.base_url + "signin"
+        url = self.base_url + "admin/login"
         contents = self.post(
             url,
             callback = False,


### PR DESCRIPTION
Login on route `/api/signin` doesn't work, but it works in route `/api/admin/login`.