### PR TITLE
feat: verify username and password

### DIFF
--- a/src/ripe/base.py
+++ b/src/ripe/base.py
@@ -70,6 +70,11 @@ class API(
         admin = admin or self.admin
         token = token or self.token
         if token: return self.login_pid(token = token)
+        appier.verify(
+            self.username and self.password,
+            "Username and password not provided",
+            403
+        )
         url = self.base_url + ("signin_admin" if admin else "signin")
         contents = self.post(
             url,


### PR DESCRIPTION
Without this we get `400` on unauthorized requests. Example flow:
- API has session_id
- Makes a request that it isn't authorized to do
- auth_callback is called
- session_id is cleared
- login tries to use username and password, which were never set
- RIPE Core returns 400 because the API made the request without the mandatory fields