### PR TITLE
#148 Add methods to change order states to "produce", "ready" and "sent"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add methods `produce_order`, `ready_order` and `send_order` to allow order state change - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
 
 ### Changed
 

--- a/src/ripe/order.py
+++ b/src/ripe/order.py
@@ -37,6 +37,52 @@ class OrderAPI(object):
         contents = self.get(url, currency = currency)
         return contents
 
+    def produce_order(
+        self,
+        number,
+        justification = None,
+        notify = False
+    ):
+        url = self.base_url + "orders/%d/produce" % number
+        contents = self.put(
+            url,
+            justification = justification,
+            notify = notify
+        )
+        return contents
+
+    def ready_order(
+        self,
+        number,
+        justification = None,
+        notify = False
+    ):
+        url = self.base_url + "orders/%d/ready" % number
+        contents = self.put(
+            url,
+            justification = justification,
+            notify = notify
+        )
+        return contents
+
+    def send_order(
+        self,
+        number,
+        justification = None,
+        notify = False,
+        tracking_number = None,
+        tracking_url = None
+    ):
+        url = self.base_url + "orders/%d/send" % number
+        contents = self.put(
+            url,
+            justification = justification,
+            notify = notify,
+            tracking_number = tracking_number,
+            tracking_url = tracking_url
+        )
+        return contents
+
     def report_pdf(self, number):
         url = self.base_url + "orders/%d/report.pdf" % number
         contents = self.get(url, number)


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Need to change order state (related to https://github.com/ripe-tech/ripe-bridge/issues/148) |
| Dependencies | -- |
| Decisions | • Created method `produce_order` that changes the order state to `produce`<br>• Created method `ready_order` that changes the order state to `ready`<br>• Created method `send_order` that changes the order state to `sent`  |

