### PR TITLE
#148 Add `strict` param to methods "produce_order", "ready_order" and "send_order"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add methods `produce_order`, `ready_order` and `send_order` to allow order state change - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
+* Add `strict` para to methods `produce_order`, `ready_order` and `send_order` - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
 
 ### Changed
 

--- a/src/ripe/order.py
+++ b/src/ripe/order.py
@@ -41,7 +41,8 @@ class OrderAPI(object):
         self,
         number,
         justification = None,
-        notify = False
+        notify = False,
+        strict = True
     ):
         url = self.base_url + "orders/%d/produce" % number
         contents = self.put(
@@ -55,7 +56,8 @@ class OrderAPI(object):
         self,
         number,
         justification = None,
-        notify = False
+        notify = False,
+        strict = True
     ):
         url = self.base_url + "orders/%d/ready" % number
         contents = self.put(
@@ -70,6 +72,7 @@ class OrderAPI(object):
         number,
         justification = None,
         notify = False,
+        strict = True,
         tracking_number = None,
         tracking_url = None
     ):


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Updates methods after changes made in https://github.com/ripe-tech/ripe-core/pull/4598 |
| Dependencies | -- |
| Decisions | Updates methods "produce_order", "ready_order" and "send_order" to support the new`strict`   |

