### PR TITLE
version: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `strict` para to methods `produce_order`, `ready_order` and `send_order` - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
 * Add `locale_to_native` and `locale_to_native_b` methods - [#4638](https://github.com/ripe-tech/ripe-core/issues/4638)
 
-
 ## [0.3.0] - 2021-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add methods `produce_order`, `ready_order` and `send_order` to allow order state change - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
-* Add `strict` para to methods `produce_order`, `ready_order` and `send_order` - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
-* Add `locale_to_native` and `locale_to_native_b` methods - [#4638](https://github.com/ripe-tech/ripe-core/issues/4638)
+*
 
 ### Changed
 
@@ -20,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 *
+
+## [0.4.0] - 2021-11-22
+
+### Added
+
+* Add methods `produce_order`, `ready_order` and `send_order` to allow order state change - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
+* Add `strict` para to methods `produce_order`, `ready_order` and `send_order` - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
+* Add `locale_to_native` and `locale_to_native_b` methods - [#4638](https://github.com/ripe-tech/ripe-core/issues/4638)
+
 
 ## [0.3.0] - 2021-08-26
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 
 setuptools.setup(
     name = "ripe-api",
-    version = "0.3.0",
+    version = "0.4.0",
     author = "Platforme International",
     author_email = "development@platforme.com",
     description = "RIPE API",


### PR DESCRIPTION
### Added

* Add methods `produce_order`, `ready_order` and `send_order` to allow order state change - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
* Add `strict` para to methods `produce_order`, `ready_order` and `send_order` - [Related to ripe-bridge/#4584](https://github.com/ripe-tech/ripe-bridge/issues/148)
* Add `locale_to_native` and `locale_to_native_b` methods - [#4638](https://github.com/ripe-tech/ripe-core/issues/4638)